### PR TITLE
feat: added native b2 sdk pusher

### DIFF
--- a/cmd/volback/main.go
+++ b/cmd/volback/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"flag"
@@ -19,6 +20,12 @@ func main() {
 
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("Configuration error: %v\n", err)
+	}
+
+	// Print the interpretted config
+	if cfg.CreateConfig {
+		fmt.Println(cfg.String())
+		return
 	}
 
 	executor, err := volback.NewExecutorFromConfig(cfg)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jacobmiller22/volume-backup
 go 1.24.0
 
 require (
+	github.com/Backblaze/blazer v0.7.2
 	github.com/aws/aws-sdk-go-v2 v1.38.3
 	github.com/aws/aws-sdk-go-v2/config v1.31.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.10

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Backblaze/blazer v0.7.2 h1:UWNHMLB+Nf+UmbO2qkVvgriODLEMz4kIyr2Hm+DVXQM=
+github.com/Backblaze/blazer v0.7.2/go.mod h1:T4y3EYa9IQ5J0PKc/C/J8/CEnSd3qa/lgNw938wZg10=
 github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
 github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 h1:i8p8P4diljCr60PpJp6qZXNlgX4m2yQFpYk+9ZT+J4E=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,8 @@ func ConfigFromFlagset(flagset *flag.FlagSet, args []string) (*Config, error) {
 	flagset.StringVar(&cfg.Destination.S3_SecretAccessKey, "dst.s3-secret-access-key", "", "The secret access key")
 	flagset.StringVar(&cfg.Destination.S3_Region, "dst.s3-region", "", "The secret access key")
 
+	flagset.BoolVar(&cfg.CreateConfig, "create-config", false, "Use this flag to produce a json version of the interpretted config")
+
 	if err := flagset.Parse(args); err != nil {
 		return nil, err
 	}
@@ -124,6 +126,13 @@ func (cl *configLoader) Load() (*Config, error) {
 	return mergeConfigs(configs...), nil
 }
 
+type B2location struct {
+	B2_ApplicationKeyId string `json:"b2_application_key_id"`
+	B2_ApplicationKey   string `json:"b2_application_key"`
+	B2_Endpoint         string `json:"b2_endpoint"`
+	B2_Bucket           string `json:"b2_bucket"`
+}
+
 type S3location struct {
 	S3_AccessKeyId     string `json:"s3_access_key_id"`
 	S3_SecretAccessKey string `json:"s3_secret_access_key"`
@@ -137,18 +146,26 @@ type Location struct {
 	Path string `json:"path"`
 
 	S3location
+	B2location
 }
 
 type Config struct {
-	JsonConfigPath string
-	Source         Location `json:"source"`
-	Restore        bool     `json:"restore"`
-	Encryption     struct {
+	Source     Location `json:"source"`
+	Restore    bool     `json:"restore"`
+	Encryption struct {
 		Key string `json:"key"`
 	} `json:"encryption"`
 	Destination Location `json:"destination"`
 
-	S3ForcePathStyle bool `env:"S3_FORCE_PATH_STYLE,default=false"`
+	JsonConfigPath   string `json:"-"`
+	S3ForcePathStyle bool   `json:"-" env:"S3_FORCE_PATH_STYLE,default=false"`
+	CreateConfig     bool   `json:"-"`
+}
+
+func (c *Config) String() string {
+	// Pretty-print the configuration
+	data, _ := json.MarshalIndent(c, "", "\t")
+	return string(data)
 }
 
 // Merges the provided configs
@@ -187,6 +204,7 @@ func mergeConfigs(configs ...*Config) *Config {
 		C.Destination.S3_Region = weakAssign(C.Destination.S3_Region, c.Destination.S3_Region)
 
 		C.S3ForcePathStyle = weakAssign(C.S3ForcePathStyle, c.S3ForcePathStyle)
+		C.CreateConfig = weakAssign(C.CreateConfig, c.CreateConfig)
 	}
 
 	return C

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,10 @@ func ConfigFromFlagset(flagset *flag.FlagSet, args []string) (*Config, error) {
 	flagset.StringVar(&cfg.Destination.S3_AccessKeyId, "dst.s3-access-key-id", "", "The access key id")
 	flagset.StringVar(&cfg.Destination.S3_SecretAccessKey, "dst.s3-secret-access-key", "", "The secret access key")
 	flagset.StringVar(&cfg.Destination.S3_Region, "dst.s3-region", "", "The secret access key")
+	flagset.StringVar(&cfg.Destination.B2_Endpoint, "dst.b2-endpoint", "", "Hostname to use as an endpoint for b2 compatible storage")
+	flagset.StringVar(&cfg.Destination.B2_Bucket, "dst.b2-bucket", "", "Name of the bucket to backup to")
+	flagset.StringVar(&cfg.Destination.B2_ApplicationKeyId, "dst.b2-application-key-id", "", "The access key id")
+	flagset.StringVar(&cfg.Destination.B2_ApplicationKey, "dst.b2-application-key", "", "The secret access key")
 
 	flagset.BoolVar(&cfg.CreateConfig, "create-config", false, "Use this flag to produce a json version of the interpretted config")
 
@@ -202,6 +206,10 @@ func mergeConfigs(configs ...*Config) *Config {
 		C.Destination.S3_Endpoint = weakAssign(C.Destination.S3_Endpoint, c.Destination.S3_Endpoint)
 		C.Destination.S3_Bucket = weakAssign(C.Destination.S3_Bucket, c.Destination.S3_Bucket)
 		C.Destination.S3_Region = weakAssign(C.Destination.S3_Region, c.Destination.S3_Region)
+		C.Destination.B2_ApplicationKeyId = weakAssign(C.Destination.B2_ApplicationKeyId, c.Destination.B2_ApplicationKeyId)
+		C.Destination.B2_ApplicationKey = weakAssign(C.Destination.B2_ApplicationKey, c.Destination.B2_ApplicationKey)
+		C.Destination.B2_Endpoint = weakAssign(C.Destination.B2_Endpoint, c.Destination.B2_Endpoint)
+		C.Destination.B2_Bucket = weakAssign(C.Destination.B2_Bucket, c.Destination.B2_Bucket)
 
 		C.S3ForcePathStyle = weakAssign(C.S3ForcePathStyle, c.S3ForcePathStyle)
 		C.CreateConfig = weakAssign(C.CreateConfig, c.CreateConfig)

--- a/internal/volback/b2.go
+++ b/internal/volback/b2.go
@@ -1,0 +1,43 @@
+package volback
+
+import (
+	"context"
+	"io"
+
+	"github.com/jacobmiller22/volume-backup/internal/config"
+
+	"github.com/Backblaze/blazer/b2"
+)
+
+func newB2Cfg(ctx context.Context, loc *config.B2location) (*b2.Client, error) {
+	client, err := b2.NewClient(ctx, loc.B2_ApplicationKeyId, loc.B2_ApplicationKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+type B2Pusher struct {
+	b2client   *b2.Client
+	bucketName string
+}
+
+func (p *B2Pusher) Push(r io.Reader, path string) error {
+	ctx := context.TODO()
+
+	bucket, err := p.b2client.Bucket(ctx, p.bucketName)
+	if err != nil {
+		return err
+	}
+
+	obj := bucket.Object(path)
+	w := obj.NewWriter(ctx)
+	defer w.Close()
+
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/internal/volback/pull.go
+++ b/internal/volback/pull.go
@@ -16,7 +16,7 @@ type Puller interface {
 func pullerFromConfig(cfg *config.Config) (Puller, error) {
 	switch cfg.Source.Kind {
 	case "s3":
-		awsCfg, err := newAwsCfg(&cfg.Source)
+		awsCfg, err := newAwsCfg(&cfg.Source.S3location)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/volback/push.go
+++ b/internal/volback/push.go
@@ -1,6 +1,7 @@
 package volback
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -16,9 +17,19 @@ type Pusher interface {
 func pusherFromConfig(cfg *config.Config) (Pusher, error) {
 
 	switch cfg.Destination.Kind {
+	case "b2":
+		b2client, err := newB2Cfg(context.TODO(), &cfg.Destination.B2location)
+		if err != nil {
+			return nil, err
+		}
+
+		return &B2Pusher{
+			b2client:   b2client,
+			bucketName: cfg.Destination.B2_Bucket,
+		}, nil
 	case "s3":
 
-		awsCfg, err := newAwsCfg(&cfg.Destination)
+		awsCfg, err := newAwsCfg(&cfg.Destination.S3location)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/volback/s3.go
+++ b/internal/volback/s3.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func newAwsCfg(loc *config.Location) (*aws.Config, error) {
+func newAwsCfg(loc *config.S3location) (*aws.Config, error) {
 
 	awsCfg, err := awsconfig.LoadDefaultConfig(
 		context.Background(),
@@ -59,8 +59,8 @@ func (p *S3PushPuller) Pull(path string) (io.Reader, error) {
 func (p *S3PushPuller) Push(r io.Reader, path string) error {
 
 	uploader := manager.NewUploader(p.s3client, func(u *manager.Uploader) {
-		u.PartSize = 8 * 1024 * 1024
-		u.Concurrency = 1
+		u.PartSize = 100 * 1024 * 1024
+
 	})
 
 	upParams := s3.PutObjectInput{
@@ -69,7 +69,9 @@ func (p *S3PushPuller) Push(r io.Reader, path string) error {
 		Body:   r,
 	}
 
-	_, err := uploader.Upload(context.Background(), &upParams)
+	_, err := uploader.Upload(context.Background(), &upParams, func(u *manager.Uploader) {
+		u.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
 
 	return err
 }


### PR DESCRIPTION
Resolves an issue where the Golang V2 S3 SDK is unable to upload a "Large" file (+4Mb) to B2 due to conflicting part size requirements. Completes this by offering a `b2` "kind" in the configuration.